### PR TITLE
Support for GitHub Enterprise Server

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ async function run(): Promise<void> {
         id,
         privateKey,
       },
+      baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com',
     });
 
     const {data} = await appOctokit.apps.listInstallations();


### PR DESCRIPTION
This action works with GitHub Enterprise Server if the GitHub API url can be injected with the GITHUB_API_URL environment variable.

GITHUB_API_URL is a default variable that is injected by GitHub Actions (https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables).