### PR TITLE
Use setSecret on installation token

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ async function run(): Promise<void> {
       type: 'installation',
       installationId: data[0].id,
     });
+    core.setSecret(resp.token);
     // @ts-ignore
     core.setOutput('token', resp.token);
   } catch (error) {


### PR DESCRIPTION
I haven't run or built this yet, but I was looking for a "trusted" (at least by name, since I'm Sentry customer) alternative to https://github.com/tibdex/github-app-token/ and I noticed that there is no call to `setSecret` in this action. Seems like there should be? Anyway I thought it would be easier just to make a PR showing the actual line change. I'd be happy to do more if that's necessary, but wanted to see what anyone thought first.

For reference:
https://github.com/actions/toolkit/tree/main/packages/core#setting-a-secret
https://github.com/tibdex/github-app-token/blob/85a43856db63fbb47ba4a5dac7584446c5e6d8e1/src/index.ts#L28