### PR TITLE
Add support of proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@octokit/auth-app": "^4.0.7",
-    "@octokit/rest": "^19.0.5"
+    "@octokit/rest": "^19.0.5",
+    "proxy-agent": "^5.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import {createAppAuth} from '@octokit/auth-app';
 import {Octokit} from '@octokit/rest';
 import {Endpoints} from '@octokit/types';
 import * as core from '@actions/core';
+import ProxyAgent from 'proxy-agent';
 
 type listInstallationsResponse =
   Endpoints['GET /app/installations']['response'];
@@ -13,6 +14,9 @@ async function run(): Promise<void> {
     const scope: string = core.getInput('scope');
     const appOctokit = new Octokit({
       authStrategy: createAppAuth,
+      request: {
+        agent: new ProxyAgent(),
+      },
       auth: {
         appId,
         privateKey,


### PR DESCRIPTION
In some cases especially the use of self-hosted runners the Github runners run behind a proxy, this is to add the support for proxy, related doc below

https://docs.github.com/en/actions/hosting-your-own-runners/using-a-proxy-server-with-self-hosted-runners#using-a-env-file-to-set-the-proxy-configuration