### PR TITLE
Use repository owner for scope by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You will need to provide the GitHub App ID and private key. The action will then
     with:
       app_id: ${{ secrets.APP_ID }}
       private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      # scope: '' # The scope for the returned token. the owner of the repo (org or account) uses current repository owner by default
 
   - name: Checkout private repo
     uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   scope:
     required: false
     description: 'Scope of installation account'
-    default: ''
+    default: '${{ github.repository_owner }}'
 outputs:
   token:
     description: 'Github Token for App installation'


### PR DESCRIPTION
closes #18

If scope parameter wasn't passed it used empty by default. 

This means a token would be returned for the first installation id on the list.

If the app had a single install this would work fine, otherwise the user will get a token scope to an owner that (probably) didn't meant to.

With this change it now uses the current repo owner (org or account).

> **Note** I don't think this is a breaking change, however some users could be accident getting the _wrong_ scope but still it was they needed by chance (if it's the first installation and the first installation is not the current owner).

As a check this step can be used to list the repos to which the returned token has access to

```yaml
- name: list repos accessible to token
   run: gh api /installation/repositories --paginate --jq .repositories.[].full_name
   env:
      GITHUB_TOKEN: ${{ steps.my-app.outputs.token }}
```

