### PR TITLE
Adding better error message when the app isn't installed to the repo

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,12 @@ async function run(): Promise<void> {
 
     const installations: listInstallationsResponse =
       await appOctokit.apps.listInstallations();
-    let installationId = installations.data[0].id;
+    let installationId;
+    try {
+      installationId = installations.data[0].id;
+    } catch (error) {
+      throw new Error(`Could not get repo installation. Is the app installed on this repo?`);
+    }
     if (scope !== '') {
       const scopedData = installations.data.find(
         (item) => item.account?.login === scope


### PR DESCRIPTION
Solves #69.
Inspired by [tibdex/github-app-token](https://github.com/tibdex/github-app-token/blob/c2055a00597a80f713b78b1650e8d3418f4d9a65/src/fetch-installation-token.ts#L43)'s error message.