### PR TITLE
Fix bug when multiple installations are available and scope is not specified

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/action-github-app-token.iml
+++ b/.idea/action-github-app-token.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,67 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <HTMLCodeStyleSettings>
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+    </HTMLCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_TYPE_BRACES" value="false" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_TYPE_BRACES" value="false" />
+    </TypeScriptCodeStyleSettings>
+    <VueCodeStyleSettings>
+      <option name="INTERPOLATION_NEW_LINE_AFTER_START_DELIMITER" value="false" />
+      <option name="INTERPOLATION_NEW_LINE_BEFORE_END_DELIMITER" value="false" />
+    </VueCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="BLOCK_COMMENT_ADD_SPACE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="BLOCK_COMMENT_ADD_SPACE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Vue">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/action-github-app-token.iml" filepath="$PROJECT_DIR$/.idea/action-github-app-token.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     required: false
     description: 'Scope of installation account'
     default: ''
+  owner:
+    required: false
+    description: 'The organization/user to generate the installation access for'
+    default: ${{ github.repository_owner }}
 outputs:
   token:
     description: 'Github Token for App installation'

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,7 @@ inputs:
     description: 'Private key for the GitHub App'
   scope:
     required: false
-    description: 'Scope of installation account'
-    default: ''
-  owner:
-    required: false
-    description: 'The organization/user to generate the installation access for'
+    description: 'Scope of installation account, defaults to the owner of the repository where the workflow is executing'
     default: ${{ github.repository_owner }}
 outputs:
   token:

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ async function run(): Promise<void> {
   try {
     const privateKey: string = core.getInput('private_key');
     const appId: string = core.getInput('app_id');
-    const scope: string = core.getInput('scope').trim();
+    const scope: string = core.getInput('scope');
     const appOctokit = new Octokit({
       authStrategy: createAppAuth,
       auth: {
@@ -28,6 +28,7 @@ async function run(): Promise<void> {
                   `set scope is ${scope}, but installation is not found`
                 );
               }
+              throw nestederror;
             });
         }
         throw error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,12 @@
 import {createAppAuth} from '@octokit/auth-app';
 import {Octokit} from '@octokit/rest';
-import {Endpoints} from '@octokit/types';
 import * as core from '@actions/core';
-
-type listInstallationsResponse =
-  Endpoints['GET /app/installations']['response'];
 
 async function run(): Promise<void> {
   try {
     const privateKey: string = core.getInput('private_key');
     const appId: string = core.getInput('app_id');
-    const scope: string = core.getInput('scope');
-    const owner: string = core.getInput('owner').trim();
+    const scope: string = core.getInput('scope').trim();
     const appOctokit = new Octokit({
       authStrategy: createAppAuth,
       auth: {
@@ -21,31 +16,23 @@ async function run(): Promise<void> {
       baseUrl: process.env.GITHUB_API_URL || 'https://api.github.com',
     });
 
-    const installations: listInstallationsResponse =
-      await appOctokit.apps.listInstallations();
-
     const response = await appOctokit.apps
-      .getOrgInstallation({org: owner})
+      .getOrgInstallation({org: scope})
       .catch(async (error) => {
         if (error.status === 404) {
-          return await appOctokit.apps.getUserInstallation({username: owner});
+          return await appOctokit.apps
+            .getUserInstallation({username: scope})
+            .catch((nestederror) => {
+              if (nestederror.status === 404) {
+                throw new Error(
+                  `set scope is ${scope}, but installation is not found`
+                );
+              }
+            });
         }
         throw error;
       });
-    let installationId = response.data.id;
-
-    if (scope !== '') {
-      const scopedData = installations.data.find(
-        (item) =>
-          item.account &&
-          'login' in item.account &&
-          item.account?.login === scope
-      );
-      if (scopedData === undefined) {
-        throw new Error(`set scope is ${scope}, but installation is not found`);
-      }
-      installationId = scopedData.id;
-    }
+    const installationId = response.data.id;
 
     // This is untyped
     // See: https://github.com/octokit/core.js/blob/master/src/index.ts#L182-L183


### PR DESCRIPTION
The way the action is currently handling fetching the installation id of an App is problematic:

```javascript
    const installations: listInstallationsResponse =
      await appOctokit.apps.listInstallations();
    let installationId = installations.data[0].id;
    if (scope !== '') {
      const scopedData = installations.data.find(
        (item) =>
          item.account &&
          'login' in item.account &&
          item.account?.login === scope
      );
      if (scopedData === undefined) {
        throw new Error(`set scope is ${scope}, but installation is not found`);
      }
      installationId = scopedData.id;
    }
```
In case a user has not specified the scope, the action will fetch the first page of all the installations (default is 30 results per page) and simply pick the first installation of these. This is problematic for the simple reason that the owner of the repository where the workflow is running might not be the only organization/user where the App is installed. 

The bug is easy to reproduce, create a GitHub App and install it on two different organizations or users. Without specifying the scope, the action will always fetch the installation access token for where you installed the GitHub App last, that surely cannot be the intended behavior.

Additionally, even if scope is specified, the `appOctokit.apps.listInstallations` call will fetch the first 30 results, if the GitHub App is installed in more than 30 organizations/users, it is possible the owner specified in the scope is not among the first 30 results returned. Pagination would solve this but a much simpler way exists.

The pull request is aimed at fixing that behavior. The default scope is the owner of the repository where the workflow is running. This is a more reliable way of fetching the installation id.