### PR TITLE
Update octokit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need to provide the GitHub App ID and private key. The action will then
 ```
   - name: my-app-install token
     id: my-app
-    uses: getsentry/action-github-app-token@v3
+    uses: getsentry/action-github-app-token@v3.1
     with:
       app_id: ${{ secrets.APP_ID }}
       private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@octokit/auth-app": "^6.0.3",
+    "@octokit/auth-app": "^7.1.1",
     "@octokit/rest": "^20.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The newer version of octokit supports using `client_id` in addition to exisitng `app_id`, which is what GitHub now recommand users to use.